### PR TITLE
Refactor worker data layer for Hive

### DIFF
--- a/lib/config/hive_config.dart
+++ b/lib/config/hive_config.dart
@@ -1,0 +1,19 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Configuración centralizada de Hive.
+class HiveConfig {
+  /// Inicializa Hive y abre las cajas necesarias.
+  static Future<void> init() async {
+    await Hive.initFlutter();
+    await Future.wait([
+      Hive.openBox('offline_data'),
+      Hive.openBox('user_data'),
+      Hive.openBox('offline_user'),
+      Hive.openBox('offline_ciudades'),
+      Hive.openBox('offline_series'),
+      Hive.openBox('offline_bloques'),
+      Hive.openBox('offline_parcelas'),
+      Hive.openBox('offline_tratamientos'),
+    ]);
+  }
+}

--- a/lib/data/hive_repository.dart
+++ b/lib/data/hive_repository.dart
@@ -1,0 +1,36 @@
+import 'package:hive/hive.dart';
+
+/// Capa de acceso a datos basada en Hive.
+class HiveRepository {
+  static final HiveRepository _instance = HiveRepository._internal();
+  factory HiveRepository() => _instance;
+  HiveRepository._internal();
+
+  Box _box(String name) => Hive.box(name);
+
+  /// Devuelve la caja para usos avanzados.
+  Box box(String name) => _box(name);
+
+  /// Obtiene un valor tal cual está almacenado.
+  dynamic get(String box, dynamic key) => _box(box).get(key);
+
+  /// Persiste un valor en la caja indicada.
+  Future<void> put(String box, dynamic key, dynamic value) async {
+    await _box(box).put(key, value);
+  }
+
+  /// Devuelve una lista o una lista vacía si la clave no existe.
+  List<dynamic> getList(String box, String key) {
+    final value = _box(box).get(key);
+    return value != null ? List<dynamic>.from(value as List) : <dynamic>[];
+  }
+
+  /// Devuelve un mapa o null si no existe.
+  Map<String, dynamic>? getMap(String box, String key) {
+    final value = _box(box).get(key);
+    if (value is Map) {
+      return Map<String, dynamic>.from(value as Map);
+    }
+    return null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'config/hive_config.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:controlgestionagro/services/offline_sync_service.dart';
@@ -30,18 +31,8 @@ void main() async {
     cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
   );
 
-  // 🔹 Inicializa Hive para almacenamiento offline
-  await Hive.initFlutter();
-  await Hive.openBox('offline_data');
-  await Hive.openBox('user_data');
-  await Hive.openBox('offline_user'); // <- caja clave
-
-  // 🔹 Data para inicio_tratamiento
-  await Hive.openBox('offline_ciudades');
-  await Hive.openBox('offline_series');
-  await Hive.openBox('offline_bloques');
-  await Hive.openBox('offline_parcelas');
-  await Hive.openBox('offline_tratamientos');
+  // 🔹 Inicializa Hive usando la nueva configuración centralizada
+  await HiveConfig.init();
 
   // 🔐 Persistencia UID anónimo si es que existe en Auth pero no está en Hive
   final userBox = Hive.box('offline_user');

--- a/lib/screens/worker/formulario_tratamiento.dart
+++ b/lib/screens/worker/formulario_tratamiento.dart
@@ -4,7 +4,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'evaluacion_dano.dart';
 import 'package:intl/intl.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive/hive.dart';
+import 'package:controlgestionagro/data/hive_repository.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 
 class AlwaysDisabledFocusNode extends FocusNode {
@@ -37,6 +38,7 @@ class FormularioTratamiento extends StatefulWidget {
 class _FormularioTratamientoState extends State<FormularioTratamiento> {
   bool guardado = false;
   late Box hiveBox;
+  final HiveRepository hive = HiveRepository();
   String? userId;
   List<dynamic> parcelas = [];
   int currentIndex = 0;
@@ -55,7 +57,7 @@ class _FormularioTratamientoState extends State<FormularioTratamiento> {
   @override
   void initState() {
     super.initState();
-    hiveBox = Hive.box('offline_tratamientos');
+    hiveBox = hive.box('offline_tratamientos');
     userId = FirebaseAuth.instance.currentUser?.uid ?? 'anon';
     cargarCiudadYSerie();
     cargarTodasLasParcelas();
@@ -318,7 +320,7 @@ class _FormularioTratamientoState extends State<FormularioTratamiento> {
     if (parcelas.isEmpty) return;
 
     final parcela = parcelas[currentIndex];
-    final box = Hive.box('offline_tratamientos');
+    final box = hive.box('offline_tratamientos');
     final id =
         parcela['id']; // asegúrate de guardar esto al momento de persistir
     final data = box.get(id);
@@ -371,7 +373,7 @@ class _FormularioTratamientoState extends State<FormularioTratamiento> {
   }
 
   Future<void> cargarTodasLasParcelas() async {
-    final box = Hive.box('offline_parcelas');
+    final box = hive.box('offline_parcelas');
     final claveBloques = 'bloques_${widget.ciudadId}_${widget.serieId}';
     final claveParcelas = 'parcelas_${widget.ciudadId}_${widget.serieId}';
 

--- a/lib/screens/worker/inicio_tratamiento.dart
+++ b/lib/screens/worker/inicio_tratamiento.dart
@@ -8,7 +8,7 @@ import 'package:uuid/uuid.dart';
 import 'package:controlgestionagro/models/tratamiento_local.dart';
 import 'package:controlgestionagro/models/query_document_snapshot_fake.dart';
 import 'package:controlgestionagro/services/offline_sync_service.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:controlgestionagro/data/hive_repository.dart';
 
 class InicioTratamientoScreen extends StatefulWidget {
   const InicioTratamientoScreen({super.key});
@@ -35,6 +35,8 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
     text: "10",
   );
 
+  final HiveRepository hive = HiveRepository();
+
   @override
   void initState() {
     super.initState();
@@ -45,7 +47,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
     if (ciudadSeleccionada == null || serieSeleccionada == null) return;
 
     final superficie = superficieController.text.trim();
-    final box = Hive.box('offline_series');
+    final box = hive.box('offline_series');
     final key = 'series_$ciudadSeleccionada';
 
     final connectivity = await Connectivity().checkConnectivity();
@@ -92,7 +94,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
   Future<void> cargarCiudades() async {
     final connectivity = await Connectivity().checkConnectivity();
     final hayConexion = connectivity != ConnectivityResult.none;
-    final box = Hive.box('offline_ciudades');
+    final box = hive.box('offline_ciudades');
     final uid = FirebaseAuth.instance.currentUser?.uid ?? 'default';
 
     if (hayConexion) {
@@ -117,7 +119,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
 
     final connectivity = await Connectivity().checkConnectivity();
     final hayConexion = connectivity != ConnectivityResult.none;
-    final box = Hive.box('offline_series');
+    final box = hive.box('offline_series');
 
     if (hayConexion) {
       final doc =
@@ -162,7 +164,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
 
     final connectivity = await Connectivity().checkConnectivity();
     final hayConexion = connectivity != ConnectivityResult.none;
-    final box = Hive.box('offline_series');
+    final box = hive.box('offline_series');
 
     if (hayConexion) {
       final snapshot =
@@ -191,7 +193,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
 
     final connectivity = await Connectivity().checkConnectivity();
     final hayConexion = connectivity != ConnectivityResult.none;
-    final box = Hive.box('offline_bloques');
+    final box = hive.box('offline_bloques');
 
     if (hayConexion) {
       final snapshot =
@@ -218,7 +220,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
 
     final connectivity = await Connectivity().checkConnectivity();
     final hayConexion = connectivity != ConnectivityResult.none;
-    final box = Hive.box('offline_parcelas');
+    final box = hive.box('offline_parcelas');
     final key =
         'parcelas_${ciudadSeleccionada}_${serieSeleccionada}_$bloqueSeleccionado';
 
@@ -526,7 +528,7 @@ class _InicioTratamientoScreenState extends State<InicioTratamientoScreen> {
             icon: const Icon(Icons.logout, color: Colors.black),
             tooltip: "Cerrar sesión",
             onPressed: () async {
-              final userBox = Hive.box('offline_user');
+              final userBox = hive.box('offline_user');
               await userBox.delete('usuario_actual');
 
               if (context.mounted) {

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -1,10 +1,12 @@
-import 'package:hive/hive.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:controlgestionagro/models/tratamiento_local.dart';
+import 'package:controlgestionagro/data/hive_repository.dart';
 
 class OfflineSyncService {
-  final _box = Hive.box('offline_data');
+  final HiveRepository _hive = HiveRepository();
   final _firestore = FirebaseFirestore.instance;
+
+  Box get _box => _hive.box('offline_data');
 
   Future<void> guardarLocal(TratamientoLocal data) async {
     await _box.add(data.toMap());


### PR DESCRIPTION
## Summary
- add `HiveConfig` with centralised Hive initialization
- introduce `HiveRepository` as a data access layer
- update `main.dart` to use the new config
- refactor worker screens and sync service to use the repository

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c156e55d88333899f5a6b25c6ada4