### PR TITLE
Implement 1‑minute Firestore sync

### DIFF
--- a/android/app/src/main/kotlin/com/example/controlgestionagro/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/controlgestionagro/AlarmReceiver.kt
@@ -1,13 +1,34 @@
 package com.example.controlgestionagro
 
+import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.SystemClock
 
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (context != null) {
-            AlarmService.startFlutterEngine(context)
+        if (context == null) return
+
+        if (intent?.action == Intent.ACTION_BOOT_COMPLETED) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val alarmIntent = Intent(context, AlarmReceiver::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                alarmIntent,
+                PendingIntent.FLAG_IMMUTABLE
+            )
+
+            alarmManager.setRepeating(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + 60_000,
+                60_000,
+                pendingIntent
+            )
         }
+
+        AlarmService.startFlutterEngine(context)
     }
 }

--- a/android/app/src/main/kotlin/com/example/controlgestionagro/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/controlgestionagro/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : FlutterActivity() {
         alarmManager.setRepeating(
             AlarmManager.ELAPSED_REALTIME_WAKEUP,
             SystemClock.elapsedRealtime() + 60_000,
-            15 * 60_000,
+            60_000,
             pendingIntent
         )
     }

--- a/lib/background_callback.dart
+++ b/lib/background_callback.dart
@@ -1,26 +1,29 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/widgets.dart';
+
+import 'config/hive_config.dart';
+import 'firebase_options.dart';
+import 'services/firestore_hive_sync_service.dart';
+
+/// Callback que se ejecuta desde un `AlarmManager` en Android.
+///
+/// Al iniciarse cada minuto, inicializa Firebase y Hive en segundo plano
+/// para luego sincronizar los datos de Firestore hacia Hive.
 void backgroundCallbackDispatcher() {
-  // Necesitas acceso a BuildContext, así que haz esto:
-  WidgetsBinding.instance.addPostFrameCallback((_) {
-    final context = navigatorKey.currentContext;
-    if (context != null) {
-      showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('🚀 Notificación'),
-          content: const Text('Hola Benjamín'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
-    }
+  WidgetsFlutterBinding.ensureInitialized();
+
+  print('Ejecutando proceso batch');
+
+  // Ejecutamos la sincronización de forma asíncrona para no bloquear
+  // la inicialización del isolate de Flutter.
+  Future(() async {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    await HiveConfig.init();
+    await syncFirestoreToHive();
   });
 }
 
-// GlobalKey para acceder al context desde cualquier lugar
-final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,7 +155,9 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('App Principal')),
-      body: const Center(child: Text('Esperando cronjob...')),
+      body: const Center(
+        child: Text('Proceso de sincronización iniciado.'),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- trigger `syncFirestoreToHive` from `backgroundCallbackDispatcher`
- initialize Firebase and Hive in the background isolate
- update `HomeScreen` to show sync start message

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a632988883338f9563103b731d63