### PR TITLE
Add background sync cronjob

### DIFF
--- a/lib/background_callback.dart
+++ b/lib/background_callback.dart
@@ -1,8 +1,13 @@
 /// Callback que se ejecuta desde un `AlarmManager` en Android.
 ///
-/// Este código es invocado incluso si la aplicación no está en primer plano,
-/// por lo que simplemente imprime un mensaje para efectos de depuración.
+/// Cada vez que el `AlarmManager` dispara (una vez por minuto) se invoca este
+/// código, incluso cuando la aplicación no está en primer plano. Aquí se
+/// delega la sincronización completa de Firestore hacia Hive.
+import 'package:controlgestionagro/services/firestore_hive_sync_service.dart';
+
 void backgroundCallbackDispatcher() {
-  print('Ejecutando proceso batch');
+  print('⏰ Ejecutando proceso batch');
+  syncFirestoreToHive();
 }
+
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,7 +155,9 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('App Principal')),
-      body: const Center(child: Text('Esperando cronjob...')),
+      body: const Center(
+        child: Text('Sincronización programada. Revisa la consola para el avance.'),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- call Firestore->Hive sync from the background callback so it runs every minute
- update HomeScreen message to indicate sync is scheduled

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ad6389c48333824ed6ce6f131c78