### PR TITLE
Add periodic sync cronjob

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="controlgestionagro"
         android:name="${applicationName}"

--- a/lib/cron/cron_resguardar.dart
+++ b/lib/cron/cron_resguardar.dart
@@ -1,0 +1,32 @@
+import 'package:workmanager/workmanager.dart';
+import 'package:firebase_core/firebase_core.dart';
+import '../services/firestore_hive_sync_service.dart';
+import '../firebase_options.dart';
+
+const String cronTaskName = 'resguardarCiudadCron';
+
+Future<void> initializeCron() async {
+  await Workmanager().initialize(
+    callbackDispatcher,
+    isInDebugMode: true,
+  );
+
+  await Workmanager().registerPeriodicTask(
+    cronTaskName,
+    cronTaskName,
+    frequency: const Duration(hours: 1),
+  );
+}
+
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    print('Ejecutando tarea cron: $task');
+
+    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+    await FirestoreHiveSyncService().syncFirestoreToHive();
+
+    print('Tarea cron finalizada: $task');
+    return Future.value(true);
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'config/hive_config.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:controlgestionagro/services/offline_sync_service.dart';
+import 'cron/cron_resguardar.dart';
 import 'firebase_options.dart';
 import 'screens/loading_screen.dart';
 import 'screens/login_screen.dart';
@@ -34,6 +35,9 @@ void main() async {
 
   // 🔹 Inicializa Hive usando la nueva configuración centralizada
   await HiveConfig.init();
+
+  // 🕒 Inicia la tarea periódica en segundo plano
+  await initializeCron();
 
   // 🔐 Persistencia UID anónimo si es que existe en Auth pero no está en Hive
   final userBox = Hive.box('offline_user');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   share_plus: ^7.2.1
   pdf: ^3.10.4
   excel: ^2.1.0
+  workmanager: ^0.7.0
  
 
 


### PR DESCRIPTION
## Summary
- add Workmanager dependency and background cron logic
- initialize cron worker in main
- allow internet permission for Android

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c18ac97c8333bb2786a030e4ae94