### PR TITLE
Add android_alarm_manager_plus integration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:label="controlgestionagro"
@@ -32,6 +34,22 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <service
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
+        <receiver
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmBroadcastReceiver"
+            android:exported="false" />
+        <receiver
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver"
+            android:enabled="false"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/background_callback.dart
+++ b/lib/background_callback.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
+@pragma('vm:entry-point')
 void backgroundCallbackDispatcher() {
-
-  //Imprimir aquí un print que indique que la tarea repetitiva está ejecutando
+  print('proceso repetitivo');
 }
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,10 @@ import 'firebase_options.dart';
 import 'screens/loading_screen.dart';
 import 'screens/login_screen.dart';
 import 'package:controlgestionagro/screens/worker/inicio_tratamiento.dart';
+import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
+import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'background_callback.dart';
 
 /// 🔄 Escucha el estado de conexión para fines de depuración o sincronización
 void monitorConexion() {
@@ -33,6 +37,12 @@ void main() async {
 
   // 🔹 Inicializa Hive usando la nueva configuración centralizada
   await HiveConfig.init();
+
+  await AndroidAlarmManager.initialize();
+  if (!kIsWeb && Platform.isAndroid) {
+    await AndroidAlarmManager.periodic(
+        const Duration(minutes: 1), 0, backgroundCallbackDispatcher);
+  }
 
   // 🔐 Persistencia UID anónimo si es que existe en Auth pero no está en Hive
   final userBox = Hive.box('offline_user');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  android_alarm_manager_plus:
+    dependency: "direct main"
+    description:
+      name: android_alarm_manager_plus
+      sha256: 3aaf2bd35177e60a7e90accd9d615d35408b556339becec22cc1284babbba8b7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.7"
   audioplayers:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
   share_plus: ^7.2.1
   pdf: ^3.10.4
   excel: ^2.1.0
+
+  android_alarm_manager_plus: ^4.0.7
  
 
 


### PR DESCRIPTION
## Summary
- add android_alarm_manager_plus dependency
- implement periodic background callback
- schedule callback from `main`
- configure Android manifest for alarm manager

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f9caa1b88333bad32e97581c2357